### PR TITLE
Bugfix/bounding local

### DIFF
--- a/include/mission_sequencer/mission_sequencer.hpp
+++ b/include/mission_sequencer/mission_sequencer.hpp
@@ -241,21 +241,13 @@ private:
   void updatePose(const geometry_msgs::PoseStamped& pose);
 
 private:
-  bool b_pose_is_valid_{ false };            //!< flag to determine if a valid pose has been received
-  bool b_odom_is_valid_{ false };            //!< flag to determine if a valid pose has been received
-  bool b_state_is_valid_{ false };           //!< flag to determine if a valid mavros state has been received
-  bool b_extstate_is_valid_{ false };        //!< flag to determine if a valid extended mavros state has been received
-  bool b_executed_landing_{ false };         //!< flag to determine if a landing command has been executed
-  bool b_is_landed_{ true };                 //!< flag to determine if the vehicle has landed
-  bool b_do_auto_state_change_{ false };     //!< \deprecated flag to determine if state changes should happen
-                                             //!< automatically or per request
-  bool b_do_automatically_land_{ false };    //!< \deprecated flag to determine if vehicle should automatically land
-  bool b_do_automatically_disarm_{ false };  //!< \deprecated flag to deterime if vehicle should be automatically
-                                             //!< disarmed
-  bool b_wp_are_relativ_{ false };  //!< \deprecated flag to determine if waypoints are relative to starting position
-  bool b_wp_is_reached_{ false };   //!< flag to determine if waypoint has been reached
-  bool b_do_verbose_{ false };      //!< flag to determine if debug output should be verbosed
-                                    //!< \deprecated will be removed in next version and replaced by the ROS debug flag
+  bool b_pose_is_valid_{ false };      //!< flag to determine if a valid pose has been received
+  bool b_odom_is_valid_{ false };      //!< flag to determine if a valid pose has been received
+  bool b_state_is_valid_{ false };     //!< flag to determine if a valid mavros state has been received
+  bool b_extstate_is_valid_{ false };  //!< flag to determine if a valid extended mavros state has been received
+  bool b_executed_landing_{ false };   //!< flag to determine if a landing command has been executed
+  bool b_is_landed_{ true };           //!< flag to determine if the vehicle has landed
+  bool b_wp_is_reached_{ false };      //!< flag to determine if waypoint has been reached
 
   // state machine
 private:

--- a/src/mission_sequencer.cpp
+++ b/src/mission_sequencer.cpp
@@ -1125,6 +1125,9 @@ void MissionSequencer::performMission()
       waypoint_list_[0].y = next_wp.pose.position.y;
       waypoint_list_[0].z = next_wp.pose.position.z;
       waypoint_list_[0].ref_frame = Waypoint::ReferenceFrame::GLOBAL;
+
+      // update next_wp
+      next_wp = waypointToPoseStamped(waypoint_list_[0]);
     }
 
     // check if waypoint is within boundaries
@@ -1476,8 +1479,8 @@ bool MissionSequencer::checkWaypoint(const geometry_msgs::PoseStamped& current_w
     wp_msg.waypoint.x = current_waypoint.pose.position.x;
     wp_msg.waypoint.y = current_waypoint.pose.position.y;
     wp_msg.waypoint.z = current_waypoint.pose.position.z;
-    wp_msg.waypoint.yaw = 0.0;       // waypoint_list_[0].yaw;
-    wp_msg.waypoint.holdtime = 0.0;  // waypoint_list_[0].holdtime;
+    wp_msg.waypoint.yaw = 0.0;  // waypoint_list_[0].yaw;
+    wp_msg.waypoint.holdtime = waypoint_list_[0].holdtime;
     pub_waypoint_reached_.publish(wp_msg);
 
     return true;

--- a/src/mission_sequencer.cpp
+++ b/src/mission_sequencer.cpp
@@ -190,7 +190,7 @@ void MissionSequencer::updatePose(const geometry_msgs::PoseStamped& pose)
     double startingYaw, startingPitch, startingRoll;
     tf2::Matrix3x3(q_NED_BODY).getEulerYPR(startingYaw, startingPitch, startingRoll);
     startingYaw = warp_to_pi(startingYaw);
-    if (b_do_verbose_)
+    if (sequencer_params_.b_do_verbose)
     {
       ROS_INFO_STREAM_THROTTLE(sequencer_params_.topic_debug_interval_,
                                "* Initial (PX4/NED) yaw= " << startingYaw * RAD_TO_DEG
@@ -483,7 +483,7 @@ void MissionSequencer::cbMSRequest(const mission_sequencer::MissionRequest::Cons
       }
       else
       {
-        if (b_do_verbose_)
+        if (sequencer_params_.b_do_verbose)
         {
           ROS_ERROR_STREAM("* mission_sequencer::request::RESUME - failed! Not in HOLD!");
         }
@@ -648,7 +648,7 @@ void MissionSequencer::cbMSRequest(const mission_sequencer::MissionRequest::Cons
       }
       else
       {
-        if (b_do_verbose_)
+        if (sequencer_params_.b_do_verbose)
         {
           ROS_WARN_STREAM("* mission_sequencer::request::READ - failed! Not in IDLE!");
         }
@@ -680,7 +680,7 @@ void MissionSequencer::cbWaypointFilename(const std_msgs::String::ConstPtr& msg)
 {
   std::string fn = msg->data.c_str();
   bool res = setWaypointFilename(fn);
-  if (b_do_verbose_)
+  if (sequencer_params_.b_do_verbose)
   {
     ROS_INFO_STREAM("Received new waypoint_filename: " << fn << "; accepted:" << res);
   }


### PR DESCRIPTION
### Summary
Fixes an issue with the bounding box, which did not take the starting yaw into account when reference was set to `LOCAL`.

### Changelog
#### Added
- Information on yaw/holdtime for reached waypoint msg.
#### Fixes
- Removes deprecated params from sequencer class and replaces old `verbose` variables.
- Updates "local" bounding box reference to include starting yaw.
- Minor issue with `CURPOS`/`CURPOSE` waypoints (not being taken immediatly).